### PR TITLE
Generate default message bodys

### DIFF
--- a/lib/event_body.ex
+++ b/lib/event_body.ex
@@ -4,6 +4,34 @@ defmodule Toskr.EventBody do
   In future, I hope for this to be more configurable.
   """
   @derive Jason.Encoder
+  alias Toskr.{
+    EventBody
+  }
 
   defstruct [:id, :context, :meta, :at, :topic]
+
+  def generate_id() do
+    UUID.uuid4()
+  end
+
+  def generate_timestamp() do
+    DateTime.utc_now()
+    |> DateTime.to_iso8601()
+  end
+
+  def default_meta() do
+    %{
+      platform: "Web",
+    }
+  end
+
+  def event_body(%{} = context, topic, meta \\ %{}) when is_map(meta) do
+    %EventBody{
+      id: generate_id(),
+      meta: Enum.into(meta, default_meta()),
+      context: context,
+      topic: topic,
+      at: generate_timestamp(),
+    }
+  end
 end

--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -24,7 +24,7 @@ defmodule Toskr.Handler do
 
     children = [%{id: Worker, restart: :transient, start: {Worker, :start_link, []}}]
     opts = [strategy: :one_for_one, subscribe_to: subs]
-    {:ok, a, con_supervisor} = ConsumerSupervisor.init(children, opts)
+    {:ok, _, _con_supervisor} = ConsumerSupervisor.init(children, opts)
   end
 
 end

--- a/lib/listener.ex
+++ b/lib/listener.ex
@@ -47,6 +47,7 @@ defmodule Toskr.Listener do
   # Helper methods
   # =====================
 
+  @spec format(any()) :: any()
   def format(opts) when is_map(opts) do
     opts
     |>Map.new(fn {k, v} -> {String.to_atom(k), format(v)} end)

--- a/lib/mock_nats.ex
+++ b/lib/mock_nats.ex
@@ -4,11 +4,11 @@ defmodule Toskr.Mat do
   """
 
   def start_link() do
-    {:ok, mat} = PubSub.start_link()
+    {:ok, _mat} = PubSub.start_link()
   end
 
   def start_link(_opts) do
-    {:ok, mat} = PubSub.start_link()
+    {:ok, _mat} = PubSub.start_link()
   end
 
   def ping(mat) when is_pid(mat) do
@@ -20,6 +20,10 @@ defmodule Toskr.Mat do
   end
 
   def sub(_mat, pid, topic) do
+    :ok = PubSub.subscribe(pid, topic)
+  end
+
+  def test_sub(pid, topic) when is_pid(pid) do
     :ok = PubSub.subscribe(pid, topic)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Toskr.MixProject do
       {:jason, "~> 1.1"},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:pubsub, "~> 1.0.0"},
+      {:elixir_uuid, "~> 1.2"},
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "1.0.3", "5278e8953f379b41ebe27c75c96d2e154ebc3f75dfe057c8b68c39133c25bb9f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.14.1", "9d46723fda072d4f4bb31a102560013f7960f5d80ea44dcb96fd6304ed61e7a4", [:mix], [], "hexpm"},
   "gnat": {:hex, :gnat, "0.6.1", "bf845324458d6b14367dc5a977ab59521f0c2e433f8fe64988095feef5baf352", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.5", [hex: :nimble_parsec, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},

--- a/test/eventbody_test.exs
+++ b/test/eventbody_test.exs
@@ -1,0 +1,65 @@
+defmodule EventBodyTest do
+  use ExUnit.Case
+  alias Toskr.{
+    EventBody,
+  }
+  require IEx
+
+  test "generate id" do
+    assert is_binary(EventBody.generate_id())
+  end
+
+  test "default meta" do
+    assert %{platform: "Web"} == EventBody.default_meta()
+  end
+
+  describe "event_body/2" do
+    test "it should populate context with the passed in map" do
+      context = %{object:
+                    %{foo: "bar"},
+                  subject:
+                    %{baz: "bop"}
+                  }
+      topic = "foo"
+      event = EventBody.event_body(context, topic)
+
+      assert %EventBody{} = event
+      assert is_binary(event.id)
+      assert {:ok, time, _} = DateTime.from_iso8601(event.at)
+      assert event.context == context
+      assert is_map(event.meta)
+      assert event.meta[:platform] == "Web"
+      assert event.topic == topic
+    end
+
+    test "the struct can be json encoded" do
+      context = %{object:
+                    %{foo: "bar"},
+                  subject:
+                    %{baz: "bop"}
+                  }
+      topic = "foo"
+      event = EventBody.event_body(context, topic)
+
+      event
+      |>Jason.encode!()
+      |>Jason.decode!()
+      |>is_map()
+    end
+
+    test "it can take in additional meta info" do
+      context = %{object:
+                    %{foo: "bar"},
+                  subject:
+                    %{baz: "bop"}
+                  }
+      topic = "foo"
+      meta = %{event_system: "NATS"}
+      expected_meta = Map.put(meta, :platform, "Web")
+      event = EventBody.event_body(context, topic, meta)
+      assert event.meta == expected_meta
+    end
+  end
+
+
+end

--- a/test/eventbody_test.exs
+++ b/test/eventbody_test.exs
@@ -41,7 +41,7 @@ defmodule EventBodyTest do
       topic = "foo"
       event = EventBody.event_body(context, topic)
 
-      event
+      assert event
       |>Jason.encode!()
       |>Jason.decode!()
       |>is_map()

--- a/test/toskr_test.exs
+++ b/test/toskr_test.exs
@@ -21,8 +21,32 @@ defmodule ToskrTest do
     assert supervisors == 1
   end
 
-  @tag :skip
-  test "it restarts both children when one dies" do
+  describe "publish" do
+    test "publishing with just the context should publish an eventbody struct" do
+      context = %{object:
+                    %{foo: "bar"},
+                  subject:
+                    %{baz: "bop"}
+                  }
+      topic = "pub.test"
+      {:ok, pid} = Gnat.start_link()
+      {:ok, subscription} = Gnat.sub(pid, self(), topic)
+      Toskr.publish(pid, topic, context: context)
+
+      receive do
+        {:msg, %{body: body}} ->
+          parsed =
+            body
+            |>Jason.decode!()
+            |>Toskr.Listener.format()
+
+          assert parsed[:topic] == topic
+          assert parsed[:context] == context
+      after
+        1000 -> flunk("No callback was received")
+      end
+
+    end
   end
 
 end

--- a/test/toskr_test.exs
+++ b/test/toskr_test.exs
@@ -30,7 +30,7 @@ defmodule ToskrTest do
                   }
       topic = "pub.test"
       {:ok, pid} = Gnat.start_link()
-      {:ok, subscription} = Gnat.sub(pid, self(), topic)
+      {:ok, _subscription} = Gnat.sub(pid, self(), topic)
       Toskr.publish(pid, topic, context: context)
 
       receive do


### PR DESCRIPTION
now generates a default message body for publishing messages further entrenching us in the event body struct. As we stray further from the light of decoupling, We should at least attempt to contemplate a world in which the eventbody can be dynamically defined to open up our use cases. But for now, we live in the sin of strong coupling. 